### PR TITLE
feat: add `resume` to agent executor

### DIFF
--- a/src/a2a/server/agent_execution/agent_executor.py
+++ b/src/a2a/server/agent_execution/agent_executor.py
@@ -42,3 +42,18 @@ class AgentExecutor(ABC):
             context: The request context containing the task ID to cancel.
             event_queue: The queue to publish the cancellation status update to.
         """
+
+    @abstractmethod
+    async def resume(
+        self, context: RequestContext, event_queue: EventQueue
+    ) -> None:
+        """Request the agent to resume a canceled task.
+
+        The agent should attempt to resume the task identified by the task_id
+        in the context and publish a `TaskStatusUpdateEvent` with state
+        `TaskState.working` to the `event_queue`.
+
+        Args:
+            context: The request context containing the task ID to resume.
+            event_queue: The queue to publish the working status update to.
+        """

--- a/tests/server/request_handlers/test_default_request_handler.py
+++ b/tests/server/request_handlers/test_default_request_handler.py
@@ -79,6 +79,9 @@ class DummyAgentExecutor(AgentExecutor):
     async def cancel(self, context: RequestContext, event_queue: EventQueue):
         pass
 
+    async def resume(self, context: RequestContext, event_queue: EventQueue):
+        pass
+
 
 # Helper to create a simple task for tests
 def create_sample_task(
@@ -789,6 +792,9 @@ class HelloAgentExecutor(AgentExecutor):
         await updater.complete()
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        pass
+
+    async def resume(self, context: RequestContext, event_queue: EventQueue):
         pass
 
 


### PR DESCRIPTION
# Description
Adds a new `resume` method to AgentExecutor
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

